### PR TITLE
Fix journal delete

### DIFF
--- a/src/models/journal.js
+++ b/src/models/journal.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose')
 
 const journal = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'user' },
-  name: { type: String, required: true }
+  name: { type: String, required: true },
+  entryIds: [{ type: mongoose.Schema.Types.ObjectId, ref: 'user' }]
 })
 
 journal.plugin(require('mongoose-autopopulate'))

--- a/src/routes/entryRoutes.js
+++ b/src/routes/entryRoutes.js
@@ -3,6 +3,7 @@ const entryRouter = express.Router()
 
 const bearerAuth = require('../middleware/bearerAuth')
 const Entry = require('../models/entry')
+const Journal = require('../models/journal')
 
 // all routes use bearerAuth middleware
 // verifies the provided access token
@@ -15,7 +16,10 @@ entryRouter.post('/create', bearerAuth, async (req, res, next) => {
   req.body.date = (new Date()).toLocaleString()
   const entry = new Entry(req.body)
   await entry.save()
-    .then(result => res.status(200).json({ entry }))
+    .then(async result => {
+      await Journal.findOneAndUpdate({ _id: req.body.journalId }, { $push: { entryIds: entry._id } })
+      res.status(200).json({ entry })
+    })
     .catch(next)
 })
 

--- a/src/routes/journalRoutes.js
+++ b/src/routes/journalRoutes.js
@@ -50,6 +50,17 @@ journalRouter.delete('/deletej', bearerAuth, async (req, res, next) => {
   const toBeDeleted = await Journal.findOne({ _id: req.body.id })
   toBeDeleted.entryIds.forEach(async (obj) => { await Entry.findByIdAndDelete(obj._id) })
   const deletedJournal = await Journal.findByIdAndDelete(req.body.id)
+  const nextJournal = await Journal.find({})
+  if (nextJournal.length > 0) {
+    await User.updateOne({ _id: req.body.userId }, { selectedJournal: nextJournal[0]._id })
+  } else {
+    const journal = new Journal({ name: 'Work', userId: req.body.userId })
+    await journal.save()
+      .then(async result => {
+        await User.updateOne({ _id: req.body.userId }, { selectedJournal: journal._id })
+      })
+      .catch(next)
+  }
   res.status(202).send(`The following journal was deleted: 
   ${deletedJournal}`)
 })

--- a/src/routes/journalRoutes.js
+++ b/src/routes/journalRoutes.js
@@ -47,12 +47,11 @@ journalRouter.put('/updatej', bearerAuth, async (req, res, next) => {
 // then deletes each entry one by one
 // finally deletes the given journal
 journalRouter.delete('/deletej', bearerAuth, async (req, res, next) => {
-  let toBeDeleted = await Entry.find({ journalId: req.body.journalId })
-  console.log(toBeDeleted)
-  // toBeDeleted.entryIds.forEach(async (obj) => { await Entry.findByIdAndDelete(obj._id) })
-  // const deletedJournal = await Journal.findByIdAndDelete(req.body.id)
+  const toBeDeleted = await Journal.findOne({ _id: req.body.id })
+  toBeDeleted.entryIds.forEach(async (obj) => { await Entry.findByIdAndDelete(obj._id) })
+  const deletedJournal = await Journal.findByIdAndDelete(req.body.id)
   res.status(202).send(`The following journal was deleted: 
-  ${toBeDeleted}`)
+  ${deletedJournal}`)
 })
 
 module.exports = journalRouter


### PR DESCRIPTION
- [x] Updated Journal schema with the array ref field, entryIds
- [x] Updated deletej route
  - [x] First deletes every entry associated with that journal
  - [x] Then deletes the journal
  - [x] Then checks if there are any remaining journals
    - [x] If there is, then the user doc's selectedJournal is updated to the first journal on the list
    - [x] Otherwise, it will create a new journal with the name work and select that one